### PR TITLE
allow O_DEFAULT_VALUE like S_IDENTIFIER(O_DEFAULT_VALUE)

### DIFF
--- a/src/mysql/parser/lexer.ne
+++ b/src/mysql/parser/lexer.ne
@@ -92,7 +92,7 @@ O_DEFAULT_VALUE ->
     %S_NUMBER             {% d => d[0].value %}
   | %S_BIT_FORMAT         {% d => d[0].value %}
   | %S_HEXA_FORMAT        {% d => d[0].value %}
-  | S_IDENTIFIER ( %S_LPARENS _ %S_RPARENS {% () => "()" %} ):?
+  | S_IDENTIFIER ( %S_LPARENS _ O_DEFAULT_VALUE:? _ %S_RPARENS {% d => d.join('') %} ):?
                           {% d => d[0] + (d[1] || '') %}
   | O_QUOTED_STRING       {% id %}
 

--- a/test/mysql/parser/create-table.spec.js
+++ b/test/mysql/parser/create-table.spec.js
@@ -37,6 +37,7 @@ runner.run({
         initials CHARACTER(5),
         created_at DATETIME(3),
         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        deleted_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
         avatar TINYBLOB,
         image BLOB(1024),
         model JSON,

--- a/test/mysql/parser/expect/create-table/0.json
+++ b/test/mysql/parser/expect/create-table/0.json
@@ -843,6 +843,40 @@
                   "id": "O_CREATE_TABLE_CREATE_DEFINITION",
                   "def": {
                     "column": {
+                      "name": "deleted_at",
+                      "def": {
+                        "datatype": {
+                          "id": "O_DATATYPE",
+                          "def": {
+                            "id": "O_DATETIME_DATATYPE",
+                            "def": {
+                              "datatype": "TIMESTAMP",
+                              "fractional": 6
+                            }
+                          }
+                        },
+                        "columnDefinition": [
+                          {
+                            "id": "O_COLUMN_DEFINITION",
+                            "def": {
+                              "nullable": false
+                            }
+                          },
+                          {
+                            "id": "O_COLUMN_DEFINITION",
+                            "def": {
+                              "default": "CURRENT_TIMESTAMP(6)"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "O_CREATE_TABLE_CREATE_DEFINITION",
+                  "def": {
+                    "column": {
                       "name": "avatar",
                       "def": {
                         "datatype": {


### PR DESCRIPTION
hi, thank you for the work, it saves me a lot :+1:

this pull request aims to solve problem when try to parse legacy mysql ddl statement with the package.

that is, sometimes default value of column need to be the form of ```identifier(value)``` at least [mysql 5.6](https://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html). 

> If a TIMESTAMP or DATETIME column definition includes an explicit fractional seconds precision value anywhere, the same value must be used throughout the column definition. This is permitted: 

``` sql
CREATE TABLE t1 (
  ts TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
);
```

but it [seems](https://github.com/duartealexf/sql-ddl-to-json-schema/blob/master/src/mysql/parser/lexer.ne#L95) that current grammer only allows to be ```identifier``` or ```identifier()```, which leads to the error like ```Unexpected S_NUMBER token: 6``` when try to parse ddl like above.

with this PR, not only number but also any default value can be placed in ```identifier(__here__)```, so that more complex default value case (I'm not sure such case happens) can be processed correctly, but if you think it over-kill, Im willing to fix it. 

regards, 