### PR TITLE
Fix datatype int issue: 1.5474250491067253e+26 -> 2147483647

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,23 @@
 
 Transforms SQL DDL statements into JSON format (JSON Schema and a compact format).
 
-- [Overview](#overview)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Shorthand](#shorthand)
-  - [Step by step](#step-by-step)
-- [Options for JSON Schema output](#options-for-json-schema-output)
-  - [`useRef`](#useref)
-- [Version compatibility table](#version-compatibility-table)
-- [What it is, what it is not](#what-it-is-what-it-is-not)
-- [About](#about)
-- [Contributing](#contributing)
-  - [Commiting](#commiting)
-  - [Understanding the internals](#understanding-the-internals)
-  - [Scripts at hand](#scripts-at-hand)
-    - [Visual Studio Code](#visual-studio-code)
-- [Links](#links)
+- [SQL DDL to JSON Schema converter](#sql-ddl-to-json-schema-converter)
+  - [Overview](#overview)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Shorthand](#shorthand)
+    - [Step by step](#step-by-step)
+  - [Options for JSON Schema output](#options-for-json-schema-output)
+    - [`useRef`](#useref)
+  - [Version compatibility table](#version-compatibility-table)
+  - [What it is, what it is not](#what-it-is-what-it-is-not)
+  - [About](#about)
+  - [Contributing](#contributing)
+    - [Commiting](#commiting)
+    - [Understanding the internals](#understanding-the-internals)
+    - [Scripts at hand](#scripts-at-hand)
+      - [Visual Studio Code](#visual-studio-code)
+  - [Links](#links)
 
 ## Overview
 
@@ -52,17 +53,13 @@ It parses and delivers an **array of JSON Schema documents** (one for each parse
     "title": "users",
     "description": "All system users",
     "type": "object",
-    "required": [
-      "id",
-      "nickname",
-      "created_at"
-    ],
+    "required": ["id", "nickname", "created_at"],
     "definitions": {
       "id": {
         "$comment": "primary key",
         "type": "integer",
         "minimum": 1,
-        "maximum": 1.5474250491067253e+26
+        "maximum": 2147483647
       },
       "nickname": {
         "type": "string",
@@ -184,7 +181,7 @@ And an array of tables in a compact JSON format:
 ]
 ```
 
-*Currently only DDL statements of MySQL and MariaDB dialects are supported.* - [Check out the roadmap](https://github.com/duartealexf/sql-ddl-to-json-schema/blob/master/ROADMAP.md)
+_Currently only DDL statements of MySQL and MariaDB dialects are supported._ - [Check out the roadmap](https://github.com/duartealexf/sql-ddl-to-json-schema/blob/master/ROADMAP.md)
 
 ## Installation
 
@@ -200,7 +197,7 @@ npm i sql-ddl-to-json-schema
 ```ts
 const { Parser } = require('sql-ddl-to-json-schema');
 // or:
-import { Parser } from 'sql-ddl-to-json-schema'
+import { Parser } from 'sql-ddl-to-json-schema';
 
 const parser = new Parser('mysql');
 
@@ -231,7 +228,6 @@ const compactJsonTablesArray = parser.feed(sql).toCompactJson(parser.results);
  * Or get the JSON Schema if you need to modify it...
  */
 const jsonSchemaDocuments = parser.feed(sql).toJsonSchemaArray(options, compactJsonTablesArray);
-
 ```
 
 ### Step by step
@@ -269,7 +265,7 @@ There are a few options when it comes to formatting the JSON Schema output:
 
 ### `useRef`
 
-Whether to add all properties to `definitions` and in `properties` only use $ref.
+Whether to add all properties to `definitions` and in `properties` only use \$ref.
 
 Default value: `true`.
 
@@ -314,26 +310,26 @@ To commit, use commitizen: `git cz` (you will need to have installed devDependen
 Folder structure:
 
 ```md
-|- lib/                   Compiled library folder, product of this project.
+|- lib/ Compiled library folder, product of this project.
 |
 |- src/
-|  |- typings/            Types used throughout project.
-|  |- shared/             Shared files used by dialects, parsers and formatters.
-|  |- mysql/
-|     |- formatter/       Formats the parsed JSON (output of parser) to other format.
-|        |- compact/      Formatter for compact JSON format.
-|        |- json-schema/  Formatter for JSON Schema format.
-|     |- language/
-|        |- dictionary/   TS files with array of keywords and symbols used in lexer.ne.
-|        |- rules/        Nearley files with grammar rules.
-|        |- lexer.ne      Entrypoint and first lines of the grammar.
+| |- typings/ Types used throughout project.
+| |- shared/ Shared files used by dialects, parsers and formatters.
+| |- mysql/
+| |- formatter/ Formats the parsed JSON (output of parser) to other format.
+| |- compact/ Formatter for compact JSON format.
+| |- json-schema/ Formatter for JSON Schema format.
+| |- language/
+| |- dictionary/ TS files with array of keywords and symbols used in lexer.ne.
+| |- rules/ Nearley files with grammar rules.
+| |- lexer.ne Entrypoint and first lines of the grammar.
 |
 |- tasks/
-|  |- mysql/
-|     |- assembly.ts      Script that concatenates all .ne files to grammar.ne to lib folder.
-|     |- formatters.ts    Script that sends a copy of formatters to lib folder.
+| |- mysql/
+| |- assembly.ts Script that concatenates all .ne files to grammar.ne to lib folder.
+| |- formatters.ts Script that sends a copy of formatters to lib folder.
 |
-|- test/                  Tests.
+|- test/ Tests.
 ```
 
 - There are naming rules for tokens in ne files, as stated in `lexer.ne`. They are prepended with:
@@ -347,7 +343,7 @@ S_ -> Symbol (not a keyword, but chars and other matches by RegExp's)
 
 ```
 
-1. The `dictionary/keywords.ts` file contains keywords, but they are prepended with K_ when used in .ne files. Take a look to make sure you understand how it is exported.
+1. The `dictionary/keywords.ts` file contains keywords, but they are prepended with K\_ when used in .ne files. Take a look to make sure you understand how it is exported.
 
 2. The compiled `grammar.ne` file comprises an assembly (concatenation) of `lexer.ne` and files in `language` folder. So don't worry about importing .ne files in other .ne files. This prevents circular dependency and grammar rules in `lexer.ne` are scoped to all files (thus not having to repeat them in every file).
 

--- a/src/mysql/formatter/json-schema/models/datatype.ts
+++ b/src/mysql/formatter/json-schema/models/datatype.ts
@@ -148,14 +148,18 @@ export class Datatype {
       /**
        * Set minimum and maximum for int.
        */
-      const width = 2 ** (8 * (this.width as number));
+      // fix: see link: https://dev.mysql.com/doc/refman/5.7/en/integer-types.html
+      // const width = 2 ** (8 * (this.width as number));
 
       if (this.isUnsigned) {
         json.minimum = 0;
-        json.maximum = width;
+        // 4294967295
+        json.maximum = 2 ** 32 - 1;
       } else {
-        json.minimum = 0 - width / 2;
-        json.maximum = 0 - json.minimum - 1;
+        // -2147483648
+        json.minimum = -1 * 2 ** 31;
+        // 2147483647
+        json.maximum = 2 ** 31 - 1;
       }
     } else if (this.datatype === 'decimal' || this.datatype === 'float') {
       /**

--- a/tests/mysql/feature/fix-datatype-int-width/parser-int-mariadb.spec.ts
+++ b/tests/mysql/feature/fix-datatype-int-width/parser-int-mariadb.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-expressions */
+
+import { Parser } from '../../../..';
+
+describe('fix-parser-int-mariadb: Parser datatype int max and min number with signed or unsigned', () => {
+  it('mariadb int signed min should be -2147483648, and max should be 2147483647', () => {
+    const sql = `
+      CREATE TABLE users (
+        id INT(11) NOT NULL AUTO_INCREMENT,
+        num INT(11) COMMENT 'test signed number',
+        PRIMARY KEY (id)
+      ) ENGINE MyISAM COMMENT 'All system users';
+    `;
+    const parser = new Parser('mariadb');
+
+    parser.feed(sql);
+
+    const arr = parser.toCompactJson(parser.results);
+    const schema = parser.toJsonSchemaArray({ useRef: false }, arr).shift();
+
+    // @ts-ignore
+    expect(schema.properties.num.minimum).toBe(-2147483648);
+    // @ts-ignore
+    expect(schema.properties.num.maximum).toBe(2147483647);
+  });
+
+  it('mariadb int unsigned min should be 0, and max should be 4294967295', () => {
+    const sql = `
+      CREATE TABLE users (
+        id INT(11) NOT NULL AUTO_INCREMENT,
+        num INT(11) UNSIGNED COMMENT 'test unsigned number',
+        PRIMARY KEY (id)
+      ) ENGINE MyISAM COMMENT 'All system users';
+    `;
+    const parser = new Parser('mariadb');
+
+    parser.feed(sql);
+
+    const arr = parser.toCompactJson(parser.results);
+    const schema = parser.toJsonSchemaArray({ useRef: false }, arr).shift();
+
+    // @ts-ignore
+    expect(schema.properties.num.minimum).toBe(0);
+    // @ts-ignore
+    expect(schema.properties.num.maximum).toBe(4294967295);
+  });
+});

--- a/tests/mysql/feature/fix-datatype-int-width/parser-int-mysql.spec.ts
+++ b/tests/mysql/feature/fix-datatype-int-width/parser-int-mysql.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-expressions */
+
+import { Parser } from '../../../..';
+
+describe('parser-int-mysql: Parser datatype int max and min number with signed or unsigned', () => {
+  it('mysql int signed min should be -2147483648, and max should be 2147483647', () => {
+    const sql = `
+      CREATE TABLE users (
+        id INT(11) NOT NULL AUTO_INCREMENT,
+        num INT(11) COMMENT 'test signed number',
+        PRIMARY KEY (id)
+      ) ENGINE MyISAM COMMENT 'All system users';
+    `;
+    const parser = new Parser('mysql');
+
+    parser.feed(sql);
+
+    const arr = parser.toCompactJson(parser.results);
+    const schema = parser.toJsonSchemaArray({ useRef: false }, arr).shift();
+
+    // @ts-ignore
+    expect(schema.properties.num.minimum).toBe(-2147483648);
+    // @ts-ignore
+    expect(schema.properties.num.maximum).toBe(2147483647);
+  });
+
+  it('mysql int unsigned min should be 0, and max should be 4294967295', () => {
+    const sql = `
+      CREATE TABLE users (
+        id INT(11) NOT NULL AUTO_INCREMENT,
+        num INT(11) UNSIGNED COMMENT 'test unsigned number',
+        PRIMARY KEY (id)
+      ) ENGINE MyISAM COMMENT 'All system users';
+    `;
+    const parser = new Parser('mysql');
+
+    parser.feed(sql);
+
+    const arr = parser.toCompactJson(parser.results);
+    const schema = parser.toJsonSchemaArray({ useRef: false }, arr).shift();
+
+    // @ts-ignore
+    expect(schema.properties.num.minimum).toBe(0);
+    // @ts-ignore
+    expect(schema.properties.num.maximum).toBe(4294967295);
+  });
+});

--- a/tests/mysql/feature/fix-datatype-int-width/readme-table-user.spec.ts
+++ b/tests/mysql/feature/fix-datatype-int-width/readme-table-user.spec.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-unused-expressions */
+
+import { Parser } from '../../../..';
+
+describe('readme-table-user: test readme table user sql', () => {
+  const sqlUserDdl = `
+    CREATE TABLE users (
+      id INT(11) NOT NULL AUTO_INCREMENT,
+      nickname VARCHAR(255) NOT NULL,
+      deleted_at TIMESTAMP NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      updated_at TIMESTAMP,
+      PRIMARY KEY (id)
+    ) ENGINE MyISAM COMMENT 'All system users';
+
+    ALTER TABLE users ADD UNIQUE KEY unq_nick (nickname);
+  `;
+
+  it('should be equal to the new maximum 2147483647', () => {
+    const parser = new Parser('mysql');
+
+    parser.feed(sqlUserDdl);
+
+    const arr = parser.toCompactJson(parser.results);
+    const schema = parser.toJsonSchemaArray({ useRef: true }, arr).shift();
+
+    // @ts-ignore
+    expect(schema.definitions.id.maximum).toEqual(2147483647);
+  });
+});

--- a/tests/mysql/formatter/json-schema/__snapshots__/formatter.spec.ts.snap
+++ b/tests/mysql/formatter/json-schema/__snapshots__/formatter.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`JSON Schema formatter: should format tables correctly, with ref. 1`] = 
         "description": "primary key test",
         "type": "integer",
         "minimum": 1,
-        "maximum": 1.2089258196146292e+24
+        "maximum": 4294967295
       },
       "name": {
         "type": "string",
@@ -38,8 +38,8 @@ exports[`JSON Schema formatter: should format tables correctly, with ref. 1`] = 
       },
       "ssn": {
         "type": "integer",
-        "minimum": -32768,
-        "maximum": 32767
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "height": {
         "type": "number",
@@ -187,8 +187,8 @@ exports[`JSON Schema formatter: should format tables correctly, with ref. 1`] = 
     "definitions": {
       "id": {
         "type": "integer",
-        "minimum": -9223372036854776000,
-        "maximum": 9223372036854776000
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "species": {
         "type": "string",
@@ -196,8 +196,8 @@ exports[`JSON Schema formatter: should format tables correctly, with ref. 1`] = 
       },
       "owner_id": {
         "type": "integer",
-        "minimum": -8388608,
-        "maximum": 8388607
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "height_unsigned": {
         "type": "number",
@@ -355,8 +355,8 @@ exports[`JSON Schema formatter: should format tables correctly, with ref. 1`] = 
       },
       "pet_id": {
         "type": "integer",
-        "minimum": -128,
-        "maximum": 127
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "coordx": {
         "type": "number",
@@ -497,7 +497,7 @@ exports[`JSON Schema formatter: should format tables correctly, without ref. 1`]
         "description": "primary key test",
         "type": "integer",
         "minimum": 1,
-        "maximum": 1.2089258196146292e+24
+        "maximum": 4294967295
       },
       "name": {
         "type": "string",
@@ -515,8 +515,8 @@ exports[`JSON Schema formatter: should format tables correctly, without ref. 1`]
       },
       "ssn": {
         "type": "integer",
-        "minimum": -32768,
-        "maximum": 32767
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "height": {
         "type": "number",
@@ -599,8 +599,8 @@ exports[`JSON Schema formatter: should format tables correctly, without ref. 1`]
     "properties": {
       "id": {
         "type": "integer",
-        "minimum": -9223372036854776000,
-        "maximum": 9223372036854776000
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "species": {
         "type": "string",
@@ -608,8 +608,8 @@ exports[`JSON Schema formatter: should format tables correctly, without ref. 1`]
       },
       "owner_id": {
         "type": "integer",
-        "minimum": -8388608,
-        "maximum": 8388607
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "height_unsigned": {
         "type": "number",
@@ -702,8 +702,8 @@ exports[`JSON Schema formatter: should format tables correctly, without ref. 1`]
       },
       "pet_id": {
         "type": "integer",
-        "minimum": -128,
-        "maximum": 127
+        "minimum": -2147483648,
+        "maximum": 2147483647
       },
       "coordx": {
         "type": "number",


### PR DESCRIPTION
### there might be a misunderstanding about the sql concept: width

### fix(src/mysql/formatter/json-schema/models/datatype.ts): 

- fix datatype int signed or unsigned with max and min number value
- tests can be found at : tests/mysql/feature/fix-datatype-int-width
- the tests have been passed
- README.md user table  maximum 1.5474250491067253e+26 changed to be 2147483647
- jest snapshots updated

### mysql datatype int links can be found at: 

- https://dev.mysql.com/doc/refman/5.7/en/integer-types.html
- https://learn.microsoft.com/en-us/sql/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql?view=sql-server-ver16
- https://dev.to/lordneic/the-enigma-of-mysqls-int11-unraveling-the-mystery-203n
